### PR TITLE
New method to wrap all the finish status for a resource

### DIFF
--- a/BigML/Response/Status.cs
+++ b/BigML/Response/Status.cs
@@ -49,6 +49,16 @@ namespace BigML
                 get { return (_status.extra as JsonValue).Select(e => (string)e); }
             }
 
+            public bool NotSuccessOrFail()
+            {
+                return (StatusCode != BigML.Code.Finished) && (StatusCode > 0);
+            }
+
+            public bool IsSuccessOrFail()
+            {
+                return !this.NotSuccessOrFail();
+            }
+
             public override string ToString()
             {
                 return _status.ToString();


### PR DESCRIPTION
Makes easier to write a method that waits until the tasks ends